### PR TITLE
Make explicit the environment variable setup phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # BackendOne
 
-Clone the project and the execute:
-
+Compile the cloned project:
 ```shell
-$ mix deps.get
-$ mix compile
+mix deps.get
+mix compile
 ```
 
-If you want start with console you can use this command line:
+Set the following AMQP related environment variables:
+* AMQP_HOST=`<rabbit-ip>`
+* AMQP_USERNAME=`<rabbit-username>`
+* AMQP_PASSWORD=`<rabbit-password>`
 
+Run all tests:
 ```shell
-$ AMQP_HOST=<rabbit-ip> AMQP_USERNAME=<rabbit-username> AMQP_PASSWORD=<rabbit-password> iex -S mix
+mix test
 ```
 
-# Execute test
+To start in console mode:
 ```shell
-$ AMQP_HOST=<rabbit-ip> AMQP_USERNAME=<rabbit-username> AMQP_PASSWORD=<rabbit-password> mix test
+iex -S mix
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 # BackendOne
 
-Compile the cloned project:
+##Compile the cloned project
 ```shell
 mix deps.get
 mix compile
 ```
 
 
-Set the following AMQP related environment variables:
-* AMQP_HOST=`<rabbit-ip>`
-* AMQP_USERNAME=`<rabbit-username>`
-* AMQP_PASSWORD=`<rabbit-password>`
+## Run all tests
 
-Run all tests:
 **Windows**
 ```shell
 SET AMQP_HOST=`<rabbit-ip>`
@@ -27,7 +23,8 @@ AMQP_HOST=`<rabbit-ip>` AMQP_USERNAME=`<rabbit-username>` AMQP_PASSWORD=`<rabbit
 ```
 
 
-Start in console mode
+## Start in console mode
+
 **Windows**
 ```shell
 SET AMQP_HOST=`<rabbit-ip>`

--- a/README.md
+++ b/README.md
@@ -6,17 +6,37 @@ mix deps.get
 mix compile
 ```
 
+
 Set the following AMQP related environment variables:
 * AMQP_HOST=`<rabbit-ip>`
 * AMQP_USERNAME=`<rabbit-username>`
 * AMQP_PASSWORD=`<rabbit-password>`
 
 Run all tests:
+**Windows**
 ```shell
+SET AMQP_HOST=`<rabbit-ip>`
+SET AMQP_USERNAME=`<rabbit-username>`
+SET AMQP_PASSWORD=`<rabbit-password>`
 mix test
 ```
 
-To start in console mode:
+**Unix/Linux/macOS**
 ```shell
+AMQP_HOST=`<rabbit-ip>` AMQP_USERNAME=`<rabbit-username>` AMQP_PASSWORD=`<rabbit-password>` mix test
+```
+
+
+Start in console mode
+**Windows**
+```shell
+SET AMQP_HOST=`<rabbit-ip>`
+SET AMQP_USERNAME=`<rabbit-username>`
+SET AMQP_PASSWORD=`<rabbit-password>`
 iex -S mix
+```
+
+**Unix/Linux/macOS**
+```shell
+AMQP_HOST=`<rabbit-ip>` AMQP_USERNAME=`<rabbit-username>` AMQP_PASSWORD=`<rabbit-password>` iex -S mix
 ```


### PR DESCRIPTION
Launching the previously detailed commands in Windows results in errors.